### PR TITLE
Prevent infinite cursor awareness update loop test locally

### DIFF
--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -241,27 +241,26 @@ export const yCursorPlugin = (
               head
             })
           }
-        } else if (
-          current.cursor != null &&
-          relativePositionToAbsolutePosition(
-            ystate.doc,
-            ystate.type,
-            Y.createRelativePositionFromJSON(current.cursor.anchor),
-            ystate.binding.mapping
-          ) !== null
-        ) {
-          // delete cursor information if current cursor information is owned by this editor binding
+        }
+      }
+
+      const unsetCursorInfo = () => {
+        const current = awareness.getLocalState() || {}
+
+        if (current[cursorStateField]) {
           awareness.setLocalStateField(cursorStateField, null)
         }
       }
+  
       awareness.on('change', awarenessListener)
       view.dom.addEventListener('focusin', updateCursorInfo)
-      view.dom.addEventListener('focusout', updateCursorInfo)
+      view.dom.addEventListener('focusout', unsetCursorInfo)
+  
       return {
         update: updateCursorInfo,
         destroy: () => {
           view.dom.removeEventListener('focusin', updateCursorInfo)
-          view.dom.removeEventListener('focusout', updateCursorInfo)
+          view.dom.removeEventListener('focusout', unsetCursorInfo)
           awareness.off('change', awarenessListener)
           awareness.setLocalStateField(cursorStateField, null)
         }


### PR DESCRIPTION
If two editors are open for the same Y.Doc, the cursor awareness state enters into an infinite update loop. This commit fixes the issue.